### PR TITLE
querystring stringification patch

### DIFF
--- a/angular2-rest.js
+++ b/angular2-rest.js
@@ -29,12 +29,10 @@ Table of Contents:
 
 */
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
-    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") return Reflect.decorate(decorators, target, key, desc);
-    switch (arguments.length) {
-        case 2: return decorators.reduceRight(function(o, d) { return (d && d(o)) || o; }, target);
-        case 3: return decorators.reduceRight(function(o, d) { return (d && d(target, key)), void 0; }, void 0);
-        case 4: return decorators.reduceRight(function(o, d) { return (d && d(target, key, o)) || o; }, desc);
-    }
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
 var __metadata = (this && this.__metadata) || function (k, v) {
     if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
@@ -189,9 +187,14 @@ function methodBuilder(name) {
                 // Query
                 var queryString = "";
                 if (pQuery) {
-                    queryString = pQuery.map(function (p) {
-                        return encodeURIComponent(p.key) + '=' + encodeURIComponent(args[p.parameterIndex]);
-                    }).join('&');
+                    queryString = pQuery
+                        .filter(function (p) { return args[p.parameterIndex]; })
+                        .map(function (p) {
+                        var key = encodeURIComponent(p.key);
+                        var value = encodeURIComponent(JSON.stringify(args[p.parameterIndex]));
+                        return key + '=' + value;
+                    })
+                        .join('&');
                 }
                 if (queryString) {
                     queryString = "?" + queryString;

--- a/angular2-rest.ts
+++ b/angular2-rest.ts
@@ -97,7 +97,7 @@ export function BaseUrl(url: string) {
 }
 
 /**
- * Set default headers for every method of the RESTClient 
+ * Set default headers for every method of the RESTClient
  * @param {Object} headers - deafult headers in a key-value pair
  */
 export function DefaultHeaders(headers: any) {
@@ -150,7 +150,7 @@ export var Header = paramBuilder("Header");
 
 
 /**
- * Set custom headers for a REST method 
+ * Set custom headers for a REST method
  * @param {Object} headersDef - custom headers in a key-value pair
  */
 export function Headers(headersDef: any) {
@@ -175,8 +175,8 @@ function methodBuilder(name: string) {
                 var body = null;
                 if (pBody) {
                     body = JSON.stringify(args[pBody[0].parameterIndex]);
-                } 
-                
+                }
+
                 // Path
                 var resUrl: string = url;
                 if (pPath) {
@@ -184,13 +184,18 @@ function methodBuilder(name: string) {
                         resUrl = resUrl.replace("{" + pPath[k].key + "}", args[pPath[k].parameterIndex]);
                     }
                 }
-                
+
                 // Query
                 var queryString = "";
                 if (pQuery) {
-                    queryString = pQuery.map(p => {
-                        return encodeURIComponent(p.key) + '=' + encodeURIComponent(args[p.parameterIndex]);
-                    }).join('&');
+                   queryString = pQuery
+                   .filter(p => args[p.parameterIndex])
+                   .map(p => {
+                       var key = encodeURIComponent(p.key)
+                       var value = encodeURIComponent(JSON.stringify(args[p.parameterIndex]))
+                       return key + '=' + value;
+                    })
+                    .join('&');
                 }
                 if (queryString) {
                     queryString = "?" + queryString;


### PR DESCRIPTION
Came across a minor issue when passing objects as querystrings :) this patch includes fixes for: 
- querystring parameters aren't `JSON.stringified` resulting in objects being passed as `"http://localhost?filter=[object Object]"`
- optional querystring parameters aren't filtered out, when empty, resulting in requests like `http://localhost?filter=undefined`
